### PR TITLE
Add SecurityControl tag with value 'Ignore' to multiple resources

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -96,6 +96,7 @@ resource "azurerm_resource_group" "main" {
   
   tags = {
     "azd-env-name" = var.environment_name
+    "SecurityControl" = "Ignore"
   }
 }
 
@@ -107,6 +108,7 @@ resource "azurerm_user_assigned_identity" "main" {
   
   tags = {
     "azd-env-name" = var.environment_name
+    "SecurityControl" = "Ignore"
   }
 }
 
@@ -125,6 +127,7 @@ resource "azurerm_storage_account" "main" {
   
   tags = {
     "azd-env-name" = var.environment_name
+    "SecurityControl" = "Ignore"
   }
 }
 
@@ -178,6 +181,7 @@ resource "azurerm_cognitive_account" "translator" {
   
   tags = {
     "azd-env-name" = var.environment_name
+    "SecurityControl" = "Ignore"
   }
 }
 
@@ -198,6 +202,7 @@ resource "azurerm_log_analytics_workspace" "main" {
   
   tags = {
     "azd-env-name" = var.environment_name
+    "SecurityControl" = "Ignore"
   }
 }
 
@@ -211,6 +216,7 @@ resource "azurerm_container_registry" "main" {
   
   tags = {
     "azd-env-name" = var.environment_name
+    "SecurityControl" = "Ignore"
   }
 }
 
@@ -230,6 +236,7 @@ resource "azurerm_container_app_environment" "main" {
   
   tags = {
     "azd-env-name" = var.environment_name
+    "SecurityControl" = "Ignore"
   }
 }
 
@@ -306,6 +313,7 @@ resource "azurerm_container_app" "translation_agent" {
   tags = {
     "azd-env-name"      = var.environment_name
     "azd-service-name"  = "translation-agent"
+    "SecurityControl"   = "Ignore"
   }
 }
 
@@ -377,6 +385,7 @@ resource "azurerm_container_app" "translation_worker" {
   tags = {
     "azd-env-name"      = var.environment_name
     "azd-service-name"  = "translation-worker"
+    "SecurityControl"   = "Ignore"
   }
 }
 
@@ -438,6 +447,7 @@ resource "azurerm_container_app" "web_gui" {
   tags = {
     "azd-env-name"      = var.environment_name
     "azd-service-name"  = "web-gui"
+    "SecurityControl"   = "Ignore"
   }
 }
 


### PR DESCRIPTION
# Pull Request Template

## Description
Please include a summary of the change and which issue is fixed. Also, include relevant motivation and context.

Fixes #(issue number)

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works


## What Changed
We add the following tag during deployment:

```terraform
    "SecurityControl"   = "Ignore" 
````

> This tag is applied where resource tags are assembled and propagates to all resources created by the deployment.

***

## Why This Is Needed

*   **MTT managed subscriptions** enforce strict Azure Policy/Guardrails. Demo resources (short-lived, non-prod) can be flagged or blocked by controls intended for production workloads.
*   Adding `SecurityControl: 'Ignore'` allows training/demo resources to **bypass or quiet specific automated controls** designed for production, ensuring workshops and demos proceed without policy denials.
* Elements such as authenticating to storage accounts with keys is prohibited.

***

## Scope

*   Applies to all Trainer Demo Deploy repos using the shared tagging pattern.
*   Only affects **tags**; no changes to resource SKUs, regions, or identities.
*   Intended specifically for **training/demo** resources in **managed MTT subscriptions**.

***

## How It Works

*   During deployment, the tag object is merged into resource definitions.
*   `SecurityControl=Ignore` signals governance to allow these workloads under curated exemptions for training/demo environments.

***

## Testing Done

*   Verified tag appears on created resources.
*   Deployed into an MTT managed subscription to confirm policy no longer blocks templates.
*   Confirmed cleanup scripts still function as expected.
